### PR TITLE
fix device name for different language & extract the method

### DIFF
--- a/lib/coremidi.rb
+++ b/lib/coremidi.rb
@@ -9,6 +9,7 @@ require 'forwardable'
 # modules
 require 'coremidi/endpoint'
 require 'coremidi/map'
+require 'coremidi/utility'
 
 # classes
 require 'coremidi/entity'

--- a/lib/coremidi/device.rb
+++ b/lib/coremidi/device.rb
@@ -66,20 +66,8 @@ module CoreMIDI
 
     # Populate the device name
     def populate_name
-      prop = Map::CF.CFStringCreateWithCString( nil, "name", 0 )
-
-      begin
-        name_ptr = FFI::MemoryPointer.new(:pointer)
-        Map::MIDIObjectGetStringProperty(@resource, prop, name_ptr)
-        name = name_ptr.read_pointer
-        len = Map::CF.CFStringGetMaximumSizeForEncoding(Map::CF.CFStringGetLength(name), :kCFStringEncodingUTF8)
-        bytes = FFI::MemoryPointer.new(len + 1)
-        raise RuntimeError.new("CFStringGetCString") unless Map::CF.CFStringGetCString(name, bytes, len, :kCFStringEncodingUTF8)
-        @name = bytes.read_string
-      ensure
-        Map::CF.CFRelease(name) unless name.nil? || name.null?
-        Map::CF.CFRelease(prop) unless prop.null?
-      end
+      @name = Utility.device_name(@resource)
+      raise RuntimeError.new("Can't get device name") unless @name
     end
     
     # All of the endpoints for all devices a consecutive local id

--- a/lib/coremidi/entity.rb
+++ b/lib/coremidi/entity.rb
@@ -58,10 +58,7 @@ module CoreMIDI
     
     # A CFString property
     def get_string(name, pointer)
-      prop = Map::CF.CFStringCreateWithCString( nil, name.to_s, 0 )
-      val = Map::CF.CFStringCreateWithCString( nil, name.to_s, 0 ) # placeholder
-      Map::MIDIObjectGetStringProperty(pointer, prop, val)
-      Map::CF.CFStringGetCStringPtr(val.read_pointer, 0).read_string rescue nil
+      Utility.device_name(name, pointer)
     end
     
     # An Integer property

--- a/lib/coremidi/utility.rb
+++ b/lib/coremidi/utility.rb
@@ -1,0 +1,29 @@
+module CoreMIDI
+
+  module Utility
+
+    def self.device_name(name = "name", resource)
+      prop = Map::CF.CFStringCreateWithCString( nil, name.to_s, 0 )
+
+      begin
+        name_ptr = FFI::MemoryPointer.new(:pointer)
+        Map::MIDIObjectGetStringProperty(resource, prop, name_ptr)
+        name = name_ptr.read_pointer
+        len = Map::CF.CFStringGetMaximumSizeForEncoding(Map::CF.CFStringGetLength(name), :kCFStringEncodingUTF8)
+
+        bytes = FFI::MemoryPointer.new(len + 1)
+
+        if Map::CF.CFStringGetCString(name, bytes, len + 1, :kCFStringEncodingUTF8)
+          bytes.read_string.force_encoding('utf-8')
+        else
+          nil
+        end
+      ensure
+        Map::CF.CFRelease(name) unless name.nil? || name.null?
+        Map::CF.CFRelease(prop) unless prop.null?
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
UniMIDI stop with RuntimeError.new("CFStringGetCString") on my laptop which set the language as 「Traditional Chinese」, but works on my office's english iMac. Turns out that UniMIDI crash because we have some multiple byte character in our device name. 

According to the [Apple Document](https://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFStringRef/Reference/reference.html#//apple_ref/c/func/CFStringGetCString), `CFStringGetCString` need one more byte of bufferSize for the `NUL` terminator. 

I extract the method to another module for returns proper name to UniMIDI also.
